### PR TITLE
Reverted write_then_readinto to write() then read()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,23 @@ Usage Example
     # For a different address use QwiicRelay(i2c, address)
     # relay = QwiicRelay(i2c, 0x19)
 
+Upgrading
+=========
+On supported GNU/Linux systems like the Raspberry Pi, you can upgrade the driver locally `from
+PyPI <https://pypi.org/project/Sparkfun-circuitpython-qwiicjoystick/>`_.
+
+To upgrade for current user:
+
+.. code-block:: shell
+
+    pip3 install --upgrade sparkfun-circuitpython-qwiicjoystick
+
+To upgrade system-wide (this may be required in some cases):
+
+.. code-block:: shell
+
+    sudo pip3 install --upgrade sparkfun-circuitpython-qwiicjoystick
+
 Contributing
 ============
 

--- a/sparkfun_qwiicrelay.py
+++ b/sparkfun_qwiicrelay.py
@@ -164,8 +164,11 @@ class Sparkfun_QwiicRelay:
     def _read_command(self, command, count):
         # Send a command then read count number of bytes.
         with self._device as device:
+            device.write(bytes([command]))
             result = bytearray(count)
-            device.write_then_readinto(bytes([command]), result)
+            device.readinto(result)
+            # write_then_readinto function does not see to work
+            # device.write_then_readinto(bytes([command]), result)
             if self._debug:
                 print("$%02X => %s" % (command, [hex(i) for i in result]))
             return result


### PR DESCRIPTION
The write_then_readinto function does not seem to read the register values correctly.  Revert back to an explicit write followed by a read.